### PR TITLE
remove safe-settings dependency

### DIFF
--- a/.github/workflows/create-repo.yml
+++ b/.github/workflows/create-repo.yml
@@ -35,67 +35,84 @@ jobs:
     if: needs.parse-issue.outputs.payload != '{}'
     steps:
       - name: Check repo name
-        env: 
-          NAME: ${{ fromJson(needs.parse-issue.outputs.payload).Name }}
-          REGEX: ${{ vars.REGEX }}
-        run: |
-          if [[ -z ${REGEX+x} || $NAME =~ $REGEX ]]; then
-            echo "Naming standard satisfied!"
-          else
-            echo "Does not match naming standard."
-            exit 1
-          fi
+        id: check-repo-name
+        uses: robandpdx/check-value-regex@v1.0.2
+        with:
+          input: ${{ fromJson(needs.parse-issue.outputs.payload).Name }}
+          regex: ${{ vars.REGEX }}
+      - name: Fail is naming standard not met
+        if: steps.check-repo-name.outputs.matches != 'true'
+        run: exit 1
   create-repo:
     runs-on: self-hosted
     needs: [parse-issue, check-name]
     if: needs.parse-issue.outputs.payload != '{}'
     steps:
-      - name: Checkout admin repo
-        uses: actions/checkout@v2
-        with:
-          repository: ${{ vars.ORG }}/admin
-          token: ${{ secrets.ADMIN_TOKEN }}
-          path: admin
-      - name: Create new repo setting from template
-        uses: bluwy/substitute-string-action@v1
-        with:
-          _input-file: admin/${{ vars.TEMPLATE }}
-          _output-file: admin/.github/repos/${{ fromJson(needs.parse-issue.outputs.payload).Name }}.yml
-          _format-key: '%%key%%'
+      - name: Create new repo
+        env:
+          TEMPLATE: ${{ vars.TEMPLATE}}
           NAME: ${{ fromJson(needs.parse-issue.outputs.payload).Name }}
           DESCRIPTION: ${{ fromJson(needs.parse-issue.outputs.payload).Description }}
-          TEAMS: ${{ join(fromJson(needs.parse-issue.outputs.payload).Teams, ',') }}
+          ADMIN_TEAM: ${{ vars.ADMIN_TEAM }}
+          GH_TOKEN: ${{ secrets.ADMIN_TOKEN }}
+          ORG: ${{ vars.ORG }}
+          VISIBILITY: ${{ vars.VISIBILITY }}
+        run: |
+          if [ -n "$TEMPLATE" ]; then
+            TEMPLATE_INCLUDE="--template $ORG/$TEMPLATE"
+          else
+            README_INCLUDE="--add-readme"
+          fi
+          case $VISIBILITY in
+            public)
+              VISIBILITY_INCLUDE="--public"
+              ;;
+            private)
+              VISIBILITY_INCLUDE="--private"
+              ;;
+            internal)
+              VISIBILITY_INCLUDE="--internal"
+              ;;
+            *)
+              VISIBILITY_INCLUDE="--private"
+              ;;
+          esac
+
+          gh repo create $ORG/$NAME \
+            --description "$DESCRIPTION" \
+            $TEMPLATE_INCLUDE \
+            $README_INCLUDE \
+            $VISIBILITY_INCLUDE
 
       - name: Add teams to repos access config
         env:
+          ADMIN_TEAM: ${{ vars.ADMIN_TEAM }}
           NAME: ${{ fromJson(needs.parse-issue.outputs.payload).Name }}
           TEAMS: ${{ join(fromJson(needs.parse-issue.outputs.payload).Teams, ',') }}
+          ORG: ${{ vars.ORG }}
+          GH_TOKEN: ${{ secrets.ADMIN_TOKEN }}
         run: |
           echo Adding $TEAMS to repo access config
           IFS=',' read -r -a array <<< "$TEAMS"
-
           for team in "${array[@]}"
           do
-              echo "Adding $team to repo access config"
-              cat <<EOF >> admin/.github/repos/$NAME.yml
-            - name: $team
-              permission: push
-          EOF
+            gh api \
+              --method PUT \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              /orgs/$ORG/teams/$team/repos/$ORG/$NAME \
+              -f "permission=push"
           done
+        
+          if [ -n "$ADMIN_TEAM" ]; then
+            gh api \
+              --method PUT \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              /orgs/$ORG/teams/$ADMIN_TEAM/repos/$ORG/$NAME \
+              -f "permission=admin"
+          fi
 
-      - name: Show the new repo settings
-        env:
-          NAME: ${{ fromJson(needs.parse-issue.outputs.payload).Name }}
-        run: cat admin/.github/repos/$NAME.yml
-
-      - name: Commit and push new repo settings file
-        uses: EndBug/add-and-commit@v9
-        with:
-          add: .github/repos/${{ fromJson(needs.parse-issue.outputs.payload).Name }}.yml
-          cwd: ./admin
-          default_author: github_actor
-          message: Repo settings for ${{ fromJson(needs.parse-issue.outputs.payload).Name }}
-          push: true
       - name: Close Issue
         uses: peter-evans/close-issue@v2
         with:

--- a/README.md
+++ b/README.md
@@ -4,20 +4,17 @@ This repo is used to automate repo creation in a target org using a GitHub Actio
 ## Background
 As a GitHub Enterprise Admin, you have certian standards for all repos in a target org. These standards may include:
  - repo naming standard
- - branch protection rules
  - standard LICENSE file
  - standard template files (CODEOWNERS, workflows, etc)
  - access via team permissions
- - anything else that [safe-settings](https://github.com/github/safe-settings) can provide
 
  You simply don't want developer running naked in the streets, creating repos all willy-nilly!!
 
 ## Solution
-Disable repo creating for all users in the target org. Users requesting a new repo will open an issue in this repo, triggering a GitHub actions workflow that will create a new repo settings file for the requested repo in your [safe-settings](https://github.com/github/safe-settings) admin repo. The new repos settings file is created from a template stored in your [safe-setting](https://github.com/github/safe-settings) admin repo. [Safe-settings](https://github.com/github/safe-settings) will apply the standard rules, configured by the admins for all repos. Upon successul addition of the new repo settings file to the [safe-setting](https://github.com/github/safe-settings) admin repo, the issue will be closed. If [safe-setting](https://github.com/github/safe-settings) is setup and working properly, the new repo will be created according to the new repo settings file.  
+Disable repo creating for all users in the target org. Users requesting a new repo will open an issue in this repo, triggering a GitHub actions workflow that will create a new repo. Upon successul repo creation, the issue will be closed.  
 
 ## Prerequisites
- - [safe-setting](https://github.com/github/safe-settings) installed and configured in the target org with an admin repo in the target org.
- - Teams defined in the target org.
+- Teams defined in the target org.
 - GitHub actions runners available for this repo.
 
 ## Configuration
@@ -26,9 +23,11 @@ You need to define the following secrets in this repo:
 `ADMIN_TOKEN` -  This needs to have write access to the safe-settings admin repo.  
 
 You need to define the following repository varaibles in this repo:  
-`TEMPLATE` - The path to the repo settings template file in the admin repo.  
 `ORG` - The org where [safe-settings](https://github.com/github/safe-settings) is installed and configured with an admin repo.  
-`REGEX` - (Optoinal) A regular expression which the repo names must adhere to. If the repo name does not match this regex, the workflow will fail and a comment will be added to the issue. If this is not defined, no naming restrictions will be applied.  
+`ADMIN_TEAM` - The team in the target org that has admin access to the new repo.  
+`REGEX` - (Optional) A regular expression which the repo names must adhere to. If the repo name does not match this regex, the workflow will fail and a comment will be added to the issue. If this is not defined, no naming restrictions will be applied.  
+`TEMPLATE` - (Optional) The name of a template repo to create the new repos from.  
+`VISIBILITY` - The visibility of the new repo. Can be `private`, `public`, or `internal`. If this is not defined, the new repo will be private.
 
 Customise the [issue template](.github/ISSUE_TEMPLATE/request_repo.yml), editing the teams field as needed. If you are implementing a naming standard for new repos, you should probably detail the standard in the issue template as well.
 


### PR DESCRIPTION
This pull request removes the dependency on [safe-settings](https://github.com/github/safe-settings) to create the repo and apply it's config. Branch protections rules should be managed through [repo rulesets](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-rulesets/about-rulesets).